### PR TITLE
Fix votekick not reporting to chat

### DIFF
--- a/lua/ulx/modules/sh/vote.lua
+++ b/lua/ulx/modules/sh/vote.lua
@@ -304,9 +304,9 @@ function ulx.votekick( calling_ply, target_ply, reason )
 
 	ulx.doVote( msg, { "Yes", "No" }, voteKickDone, _, _, _, target_ply, time, calling_ply, reason )
 	if reason and reason ~= "" then
-		ulx.fancyLogAdmin( calling_ply, "#A started a votekick against #T (#s)", minutes, target_ply, reason )
+		ulx.fancyLogAdmin( calling_ply, "#A started a votekick against #T (#s)", target_ply, reason )
 	else
-		ulx.fancyLogAdmin( calling_ply, "#A started a votekick against #T", minutes, target_ply )
+		ulx.fancyLogAdmin( calling_ply, "#A started a votekick against #T", target_ply )
 	end
 end
 local votekick = ulx.command( CATEGORY_NAME, "ulx votekick", ulx.votekick, "!votekick" )


### PR DESCRIPTION
The fancyLogAdmin had a 'minutes' arguement which is not present in votekicks, resulting in the message not being shown.