### PR TITLE
Fix for reading addon info from addon.txt

### DIFF
--- a/lua/ulx/modules/sh/menus.lua
+++ b/lua/ulx/modules/sh/menus.lua
@@ -103,7 +103,9 @@ if ULib.fileExists( "lua/ulx/modules/cl/motdmenu.lua" ) or ulx.motdmenu_exists t
 					if ULib.fileExists( "addons/" .. addon .. "/addon.txt" ) then
 						local t = ULib.parseKeyValues( ULib.fileRead( "addons/" .. addon .. "/addon.txt" ) ).AddonInfo
 						if t then
-							table.insert( ulx.motdSettings.addons, { title=addon, author=t.author_name } )
+							local name = addon
+							if t.name then name = t.name end
+							table.insert( ulx.motdSettings.addons, { title=name, author=t.author_name } )
 						end
 					end
 				end

--- a/lua/ulx/modules/sh/menus.lua
+++ b/lua/ulx/modules/sh/menus.lua
@@ -101,7 +101,7 @@ if ULib.fileExists( "lua/ulx/modules/cl/motdmenu.lua" ) or ulx.motdmenu_exists t
 				local _, possibleaddons = file.Find( "addons/*", "GAME" )
 				for _, addon in ipairs( possibleaddons ) do
 					if ULib.fileExists( "addons/" .. addon .. "/addon.txt" ) then
-						local t = ULib.parseKeyValues( ULib.stripComments( ULib.fileRead( "addons/" .. addon .. "/addon.txt" ), "//" ) )
+						local t = ULib.parseKeyValues( ULib.fileRead( "addons/" .. addon .. "/addon.txt" ) ).AddonInfo
 						if t then
 							table.insert( ulx.motdSettings.addons, { title=addon, author=t.author_name } )
 						end

--- a/lua/ulx/modules/sh/util.lua
+++ b/lua/ulx/modules/sh/util.lua
@@ -322,7 +322,7 @@ function ulx.debuginfo( calling_ply )
 			local name = addon
 			local author, version, date
 			if ULib.fileExists( "addons/" .. addon .. "/addon.txt" ) then
-				local t = ULib.parseKeyValues( ULib.stripComments( ULib.fileRead( "addons/" .. addon .. "/addon.txt" ), "//" ) )
+				local t = ULib.parseKeyValues( ULib.fileRead( "addons/" .. addon .. "/addon.txt" ) ).AddonInfo
 				if t then
 					if t.name then name = t.name end
 					if t.version then version = t.version end


### PR DESCRIPTION
Noticed the addon author did not display properly in the default motd for non workshop addons.
Made this quick fix and also made the motd show a proper name from addon.txt for non workshop addons instead of its folder name.
Removed stripComments because it caused issues with author_url (it removed everything after http://)
