### PR TITLE
Disable PM's for Muted Users

### DIFF
--- a/lua/ulx/modules/sh/chat.lua
+++ b/lua/ulx/modules/sh/chat.lua
@@ -3,6 +3,11 @@ CATEGORY_NAME = "Chat"
 
 ------------------------------ Psay ------------------------------
 function ulx.psay( calling_ply, target_ply, message )
+	if calling_ply:GetNWBool('ulx_muted', false) then 
+		ULib.tsayError( calling_ply, "You are muted, and therefore cannot speak!", true )
+		return
+	end
+	
 	ulx.fancyLog( { target_ply, calling_ply }, "#P to #P: " .. message, calling_ply, target_ply )
 end
 local psay = ulx.command( CATEGORY_NAME, "ulx psay", ulx.psay, "!p", true )


### PR DESCRIPTION
I've seen this happen a lot where a user get's muted for chat spam and then continues to spam everyone in the server with ulx psay and you can't do anything about it but kick them (which sucks if the staff don't have permissions to do so).
So I thought, why not just disable PM's for said muted players. 

It's not like they need to message anyone, they're muted for a reason. If they really have an issue, there's always Admin Chat!