### PR TITLE
Allow custom hints in XGUI for time parameters

### DIFF
--- a/lua/ulx/modules/cl/xgui_helpers.lua
+++ b/lua/ulx/modules/cl/xgui_helpers.lua
@@ -236,7 +236,7 @@ function xgui.load_helpers()
 			local max = restrictions.max or 10 * 60 * 24 * 365 --default slider max 10 years
 
 			local outPanel = xlib.makepanel{ h=40, parent=parent }
-			xlib.makelabel{ x=5, y=3, label="Ban Length:", parent=outPanel }
+			xlib.makelabel{ x=5, y=3, label=arg.hint or "Time:", parent=outPanel }
 			outPanel.interval = xlib.makecombobox{ x=90, w=75, parent=outPanel }
 			outPanel.val = xlib.makeslider{ w=165, y=20, label="<--->", min=min, max=max, value=min, decimal=0, parent=outPanel }
 

--- a/lua/ulx/modules/sh/util.lua
+++ b/lua/ulx/modules/sh/util.lua
@@ -99,7 +99,7 @@ function ulx.ban( calling_ply, target_ply, minutes, reason )
 end
 local ban = ulx.command( CATEGORY_NAME, "ulx ban", ulx.ban, "!ban", false, false, true )
 ban:addParam{ type=ULib.cmds.PlayerArg }
-ban:addParam{ type=ULib.cmds.NumArg, hint="minutes, 0 for perma", ULib.cmds.optional, ULib.cmds.allowTimeString, min=0 }
+ban:addParam{ type=ULib.cmds.NumArg, hint="Ban Length", ULib.cmds.optional, ULib.cmds.allowTimeString, min=0 }
 ban:addParam{ type=ULib.cmds.StringArg, hint="reason", ULib.cmds.optional, ULib.cmds.takeRestOfLine, completes=ulx.common_kick_reasons }
 ban:defaultAccess( ULib.ACCESS_ADMIN )
 ban:help( "Bans target." )
@@ -142,7 +142,7 @@ function ulx.banid( calling_ply, steamid, minutes, reason )
 end
 local banid = ulx.command( CATEGORY_NAME, "ulx banid", ulx.banid, "!banid", false, false, true )
 banid:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
-banid:addParam{ type=ULib.cmds.NumArg, hint="minutes, 0 for perma", ULib.cmds.optional, ULib.cmds.allowTimeString, min=0 }
+banid:addParam{ type=ULib.cmds.NumArg, hint="Ban Length", ULib.cmds.optional, ULib.cmds.allowTimeString, min=0 }
 banid:addParam{ type=ULib.cmds.StringArg, hint="reason", ULib.cmds.optional, ULib.cmds.takeRestOfLine, completes=ulx.common_kick_reasons }
 banid:defaultAccess( ULib.ACCESS_SUPERADMIN )
 banid:help( "Bans steamid." )


### PR DESCRIPTION
Currently, if you use a param with time strings allowed, the hint in XGUI will _always_ appear as "Ban Length:". This is fine for the default ULX uses of this, where it's only used by `ulx ban` and `ulx banid`, but it doesn't make sense for other uses that aren't involving bans. This PR changes this to use the param's `hint` if it has one, or "Time:" if it doesn't.