### PR TITLE
Fix Orphaned Panels

### DIFF
--- a/lua/ulx/modules/cl/xlib.lua
+++ b/lua/ulx/modules/cl/xlib.lua
@@ -100,7 +100,7 @@ function xlib.makelabel( t )
 	return pnl
 end
 
-function xlib.makelistlayout( t )
+function xlib.makescrolledlistlayout( t )
 	local pnl = vgui.Create( "DListLayout" )
 	pnl.scroll = vgui.Create( "DScrollPanel", t.parent )
 
@@ -114,6 +114,26 @@ function xlib.makelistlayout( t )
 		self:SizeToChildren( false, true )
 		self:SetWide( self.scroll:GetWide() - ( self.scroll.VBar.Enabled and 16 or 0 ) )
 	end
+
+	return pnl
+end
+
+function xlib.makelistlayout( t )
+	-- Backwards compat (if a parent is provided, make it scrollable)
+	if IsValid( t.parent ) and t.parent ~= xgui.null then
+		return xlib.makescrolledlistlayout( t )
+	end
+
+	local pnl = vgui.Create( "DListLayout" )
+
+	pnl:SetPos( t.x, t.y )
+	pnl:SetSize( t.w, t.h )
+	pnl:SetZPos( t.zpos or 0 )
+
+	function pnl:PerformLayout()
+		self:SizeToChildren( false, true )
+	end
+
 	return pnl
 end
 


### PR DESCRIPTION
Currently, `xlib.makelistlayout()` generates a DScrollPanel (parented to whatever is in the `parent` field), adds a child DListLayout, and then returns that child. However, many parts of ulx immediately orphan the DScrollPanel by reparenting the DListLayout to something else, leaving it behind.

Whenever `xlib.makelistlayout()` is given `parent=xgui.null` (the always-hidden, zero-size dumping grounds panel), this is fine and doesn't amount to much, since the DScrollPanel gets parented to `xgui.null` and becomes effectively nonexistant.

If no parent is supplied, however, it instead leaves the DScrollPanel on the GModBase panel. As a result, several invisible, yet active scroll panels end up attached to GModBase, including one in particular with a non-zero height that causes it to block mouse input in some cases (e.g. PAC3 camera, and some vgui elements if moved to the top left corner).
Shown here is the non-zero-height panel (in red) and the list of other orphaned panels (in cyan) in `vgui_drawtree 1`
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0a3d5db4-1bf2-48c2-bd8a-70d531afc2e6" />

As a fix, this pr reworks `xlib.makelistlayout()` to only create the DScrollPanel if a valid parent panel besides `xgui.null` is passed. Or in other words, it only makes the scroll panel when it's actually going to get used.

A potentially cleaner fix would be to split `xlib.makelistlayout()` into two functions, one that makes a scroll panel and one that never does, and then change each appearance of the function in ulx accordingly. However, I figured this would be more suitable as it doesn't have to touch several other files and potentially break if other addons use xgui in the same way. If maintainers would prefer the second option, I can easily switch the pr to do that instead.

