### PR TITLE
fix: guard crash-prone runtime paths

### DIFF
--- a/lua/ulx/log.lua
+++ b/lua/ulx/log.lua
@@ -314,7 +314,7 @@ local function updateColors()
 	for i=1, #cvars do
 		local cvar = cvars[ i ]
 		local pieces = ULib.explode( "%s+", cvar:GetString() )
-		if not #pieces == 3 then Msg( "Warning: Tried to set ulx log color cvar with bad data\n" ) return end
+		if #pieces ~= 3 then Msg( "Warning: Tried to set ulx log color cvar with bad data\n" ) return end
 		local color = Color( tonumber( pieces[ 1 ] ), tonumber( pieces[ 2 ] ), tonumber( pieces[ 3 ] ) )
 
 		if cvar == logEchoColorDefault then default_color = color

--- a/lua/ulx/modules/sh/fun.lua
+++ b/lua/ulx/modules/sh/fun.lua
@@ -434,6 +434,11 @@ jail:setOpposite( "ulx unjail", {_, _, _, true}, "!unjail" )
 
 ------------------------------ Jail TP ------------------------------
 function ulx.jailtp( calling_ply, target_ply, seconds )
+	if not calling_ply:IsValid() then
+		Msg( "You can't teleport and jail from the dedicated server console.\n" )
+		return
+	end
+
 	local t = {}
 	t.start = calling_ply:GetPos() + Vector( 0, 0, 32 ) -- Move them up a bit so they can travel across the ground
 	t.endpos = calling_ply:GetPos() + calling_ply:EyeAngles():Forward() * 16384
@@ -781,6 +786,7 @@ local function createRagdollAfterCleanup()
 		if ply.ragdollAfterCleanup then
 			ply.ragdollAfterCleanup = nil
 			timer.Simple( 0.1, function() -- Doesn't like us re-creating the ragdoll immediately
+				if not ply:IsValid() then return end
 				ulx.ragdollPlayer( ply )
 			end)
 		end
@@ -817,7 +823,7 @@ zombieDeath = function( ent, ply )
 		local pos = ent:GetPos()
 		local ang = ent:GetAngles()
 		ULib.queueFunctionCall( function() -- Create it next frame because 1. Old NPC won't be in way and 2. We won't overflow the server while shutting down with someone being mauled
-			if not ply:IsValid() then return end -- Player left
+			if not ply:IsValid() or not ply.maul_npcs then return end -- Player left or maul ended
 
 			local ent2 = newZombie( pos, ang, ply )
 			table.insert( ply.maul_npcs, ent2 ) -- Don't worry about removing the old one, doesn't matter.

--- a/lua/ulx/modules/sh/rcon.lua
+++ b/lua/ulx/modules/sh/rcon.lua
@@ -93,6 +93,7 @@ function ulx.ent( calling_ply, classname, params )
 
 	newEnt:SetPos( vector ) -- Note that the position can be overridden by the user's flags
 
+	params = params or ""
 	params:gsub( "([^|:\"]+)\"?:\"?([^|]+)", function( key, value )
 		key = key:Trim()
 		value = value:Trim()


### PR DESCRIPTION
## Summary
- avoid a nil optional-argument crash in `ulx ent`
- reject dedicated-server-console use of `ulx jailtp` before reading player position
- re-check stale players/state in delayed ragdoll and maul callbacks
- fix malformed log color validation so bad cvar data is rejected

## Why
These paths can be reached during normal admin usage or delayed callbacks after a player has disconnected or a state has ended. The changes add narrow guards without changing command permissions, target selection, damage, jail, ragdoll, or maul behavior.

## Checks
- `git diff --check`
- manual review of touched call sites